### PR TITLE
Resolve errors 'NameError: uninitialized constant' from lib/push_bot/request.rb

### DIFF
--- a/lib/push_bot/request.rb
+++ b/lib/push_bot/request.rb
@@ -1,3 +1,6 @@
+require 'typhoeus'
+require 'json'
+
 module PushBot
   class Request
     def initialize(base)

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe PushBot::Request do
+  describe "#request" do
+    describe "POST" do
+      let(:type){:all}
+      let(:options){{msg:'foo',platform: '0'}}
+      it "Typhoeus::Request should receive #new" do
+        expect(Typhoeus::Request).to receive(:new)
+        described_class.new(:push).post(type, options)
+      end
+    end
+  end #request
+end

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -3,10 +3,27 @@ require 'spec_helper'
 describe PushBot::Request do
   describe "#request" do
     describe "POST" do
+      let(:id){42}
+      let(:secret){'super_secret_key'}
       let(:type){:all}
       let(:options){{msg:'foo',platform: '0'}}
+      let(:request_options){{
+        method: :post,
+        body: JSON.dump(options),
+        headers: {
+          :'X-PushBots-AppID' => id,
+          :'X-PushBots-Secret' => secret,
+          :'Content-Type' => :'application/json'
+        }
+      }}
+      before do
+        PushBot.configure do |config|
+          config.id = id
+          config.secret = secret
+        end
+      end
       it "Typhoeus::Request should receive #new" do
-        expect(Typhoeus::Request).to receive(:new)
+        expect(Typhoeus::Request).to receive(:new).with("https://api.pushbots.com/push/#{type}",request_options)
         described_class.new(:push).post(type, options)
       end
     end


### PR DESCRIPTION
This was causing errors on the following platform:

    interpreter:  "ruby"
    version:      "1.9.3p548"
    date:         "2014-09-06"
    platform:     "x86_64-darwin13.4.0"
    patchlevel:   "2014-09-06 revision 47430"
    full_version: "ruby 1.9.3p548 (2014-09-06 revision 47430) [x86_64-darwin13.4.0]"